### PR TITLE
Stop validation check from occurring during component re-renders

### DIFF
--- a/src/routes/util.tsx
+++ b/src/routes/util.tsx
@@ -1,6 +1,5 @@
-import React, { FC } from 'react'
+import React, { FC, useState, useEffect } from 'react'
 import { Route, RouteProps } from 'react-router-dom'
-import { useState } from 'react'
 import { useHistory } from 'react-router-dom'
 import Auth from '../auth'
 
@@ -32,15 +31,17 @@ const AuthProxy: React.FunctionComponent<{ component: React.ComponentClass }> = 
   const history = useHistory()
 
   // validate user
-  Auth.validate().then(isValid => {
-    if (!isValid) {
-      // If auth token is invalid, redirect to login
-      history.push('/login')
-    } else {
-      // Else show login
-      setReady(true)
-    }
-  })
+  useEffect(function () {
+    Auth.validate().then(isValid => {
+      if (!isValid) {
+        // If auth token is invalid, redirect to login
+        history.push('/login')
+      } else {
+        // Else show login
+        setReady(true)
+      }
+    })
+  }, [null])
 
   let [ready, setReady] = useState(false)
 

--- a/src/routes/util.tsx
+++ b/src/routes/util.tsx
@@ -41,7 +41,8 @@ const AuthProxy: React.FunctionComponent<{ component: React.ComponentClass }> = 
         setReady(true)
       }
     })
-  }, [null])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   let [ready, setReady] = useState(false)
 


### PR DESCRIPTION
Currently the `AuthProxy` component performs a call to the Spotify API every time a child component updates, which is undesired. This PR stops this behaviour