### PR TITLE
Auto-load and cache playlists on open

### DIFF
--- a/src/components/PlaylistWrapper/PlaylistSelector.tsx
+++ b/src/components/PlaylistWrapper/PlaylistSelector.tsx
@@ -1,6 +1,6 @@
 /* UI component to select a playlist */
 
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 
 import { makeStyles } from '@material-ui/core/styles'
 
@@ -34,19 +34,24 @@ const useStyles = makeStyles({
   }
 })
 
+let playlistCache: Playlist[] = [];
+
 export default function (props: { onSelect: (playlist: Playlist) => void }) {
   const classes = useStyles()
 
   async function handleRefresh () {
     setLoading(true)
-    let res = await getPlaylists()
-    setPlaylists(res)
+    setPlaylists((playlistCache = await getPlaylists()))
     setLoading(false)
   }
-
-  let [playlists, setPlaylists] = useState<Playlist[]>([])
+  
+  let [playlists, setPlaylists] = useState<Playlist[]>(playlistCache)
   let [loading, setLoading] = useState(false)
   let [search, setSearch] = useState('')
+
+  useEffect(() => {
+    handleRefresh()
+  }, [])
 
   return (
     <Card className={classes.root}>


### PR DESCRIPTION
Currently the `Refresh` button needs to be pressed in order to load the user's playlists.

This PR proposes a change to automatically start the refresh functionality when the dialogue is opened.

In addition, the result of a previous refresh call is cached between all Playlist Selectors, so the wait delay can be skipped for subsequent opens