### PR TITLE
added song preview on click and onhoverclose

### DIFF
--- a/src/components/Track.tsx
+++ b/src/components/Track.tsx
@@ -8,15 +8,33 @@ export default function Track (props: {
   isDragging?: boolean
 }): JSX.Element {
   const [popupAnchor, setPopupAnchor] = React.useState(null)
+  var audio = new Audio(props.track.preview_url)
+  const[playing, setPlaying] = React.useState(false)
 
   const handlePopoverOpen = (event: any) => {
     props.isDragging || setPopupAnchor(event.currentTarget)
   }
 
   const handlePopoverClose = () => {
+    if (playing === true){
+      audio.pause()
+      setPlaying(false)
+      console.log('its pausing !')
+    }
     setPopupAnchor(null)
   }
-
+  const handlePreviewClick = () => {
+      if (playing === false){
+        audio.play()
+        setPlaying(true)
+        console.log('its playing !')
+      }else{
+        audio.pause()
+        setPlaying(false)
+        console.log('its pausing !')
+      }
+  }
+  
   return (
     <React.Fragment>
       <ListItemText>
@@ -24,6 +42,7 @@ export default function Track (props: {
           aria-haspopup='true'
           onMouseEnter={handlePopoverOpen}
           onMouseLeave={handlePopoverClose}
+          onClick = {handlePreviewClick}
           align='center'
         >
           {props.track.name}

--- a/src/components/Track.tsx
+++ b/src/components/Track.tsx
@@ -15,25 +15,21 @@ export default function Track (props: {
   const handlePopoverOpen = (event: any) => {
     props.isDragging || setPopupAnchor(event.currentTarget)
   }
-
+  const handlePlaying = () =>{
+    audio.pause()
+    setPlaying(false)
+  }
+  const handlePaused = () =>{
+    audio.play()
+    setPlaying(true)
+  }
   const handlePopoverClose = () => {
-    if (playing === true){
-      audio.pause()
-      setPlaying(false)
-      console.log('its pausing !')
-    }
+    if (playing) handlePlaying()
     setPopupAnchor(null)
   }
+
   const handlePreviewClick = () => {
-      if (playing === false){
-        audio.play()
-        setPlaying(true)
-        console.log('its playing !')
-      }else{
-        audio.pause()
-        setPlaying(false)
-        console.log('its pausing !')
-      }
+      playing?handlePlaying():handlePaused()
   }
   
   return (

--- a/src/components/Track.tsx
+++ b/src/components/Track.tsx
@@ -8,7 +8,8 @@ export default function Track (props: {
   isDragging?: boolean
 }): JSX.Element {
   const [popupAnchor, setPopupAnchor] = React.useState(null)
-  var audio = new Audio(props.track.preview_url)
+  // eslint-disable-next-line
+  const [audio, setAudio] = React.useState(new Audio(props.track.preview_url));
   const[playing, setPlaying] = React.useState(false)
 
   const handlePopoverOpen = (event: any) => {

--- a/src/types/Track.tsx
+++ b/src/types/Track.tsx
@@ -17,7 +17,7 @@ export interface Track {
   // is_local: boolean
   name: string
   popularity: Number
-  preview_url: string | null
+  preview_url: string | undefined
   track_number: Number
   type: string
   uri: string


### PR DESCRIPTION
Song Preview

<!-- This is a template - do add to or remove from as needed -->
<!-- Please provide a general summary of your changes in the Title above 🚀 -->
## Context

https://www.pivotaltracker.com/story/show/175033851

## Description 💬
- Song previews play on click of the text and stop playing off hover as well as on second click.

-Please leave comments on:
-  should the text play the song or should we add a button to the track component (personally I think it could be overwhelming for a user  + cluttered to see all the popup information as well as draggable icons as well as a play pause icon leaving the preview as more of a bonus functionality rather than a core functionality of looking at the songs)
 + general thoughts on current implementation 

## Checklist ✅:
<!-- Go over all the following points, and check all the boxes. -->
-  [x] I assigned the story to myself on Pivotal Tracker before I started working on this
-  [x] Added a link to the user story context
- [x] Added a description of my changes
- [x] Assigned at least two reviewers
<!-- Once you've checked all of these you can probably delete this checklist for brevity -->
