### PR TITLE
Performance improvements for audio preview

### DIFF
--- a/src/components/Track.tsx
+++ b/src/components/Track.tsx
@@ -8,28 +8,28 @@ export default function Track (props: {
   isDragging?: boolean
 }): JSX.Element {
   const [popupAnchor, setPopupAnchor] = React.useState(null)
-  // eslint-disable-next-line
-  const [audio, setAudio] = React.useState(new Audio(props.track.preview_url));
-  const[playing, setPlaying] = React.useState(false)
+  
+  const audio = props.track.preview_url && new Audio(props.track.preview_url)
 
   const handlePopoverOpen = (event: any) => {
     props.isDragging || setPopupAnchor(event.currentTarget)
   }
-  const handlePlaying = () =>{
-    audio.pause()
-    setPlaying(false)
-  }
-  const handlePaused = () =>{
-    audio.play()
-    setPlaying(true)
-  }
+
   const handlePopoverClose = () => {
-    if (playing) handlePlaying()
+    audio && audio.pause()
     setPopupAnchor(null)
   }
 
   const handlePreviewClick = () => {
-      playing?handlePlaying():handlePaused()
+    if (audio) {
+      if (!audio.paused || audio.currentTime) {
+        audio.pause()
+        
+      } else {
+        audio.currentTime = 0
+        audio.play()
+      }
+    }
   }
   
   return (

--- a/src/components/Track.tsx
+++ b/src/components/Track.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Track as TrackObj } from '../types'
 import TrackPopup from './TrackPopup'
 import { ListItemText, Typography } from '@material-ui/core'
@@ -7,7 +7,7 @@ export default function Track (props: {
   track: TrackObj
   isDragging?: boolean
 }): JSX.Element {
-  const [popupAnchor, setPopupAnchor] = React.useState(null)
+  const [popupAnchor, setPopupAnchor] = useState(null)
   
   const audio = props.track.preview_url && new Audio(props.track.preview_url)
 

--- a/src/types/Track.tsx
+++ b/src/types/Track.tsx
@@ -17,7 +17,7 @@ export interface Track {
   // is_local: boolean
   name: string
   popularity: Number
-  preview_url: string | undefined
+  preview_url?: string
   track_number: Number
   type: string
   uri: string


### PR DESCRIPTION
Currently when a Track is loaded, it creates a HTML5 `HTMLAudioElement` element, _even_ if there is no supplied preview url.  
This PR proposes to only create the `HTMLAudioElement` **only if** the preview URL is supplied.

The `audio` "state" and `playing` states have also been removed to simplify component creation.

The `playing` state could be introduced if there were to be a visual indicator of a track's preview status

<details><summary>This removes console message spam (Click to view)</summary>

![image](https://user-images.githubusercontent.com/1159091/98693665-ae506a80-23c4-11eb-9af6-0611d4a77dd8.png)

</details>