### PR TITLE
Default All Genre

### DIFF
--- a/src/components/GenreSelector.tsx
+++ b/src/components/GenreSelector.tsx
@@ -17,7 +17,8 @@ export default function (props: {
     <Autocomplete
       multiple
       fullWidth={true}
-      options={props.genres}
+      options={["all"].concat(props.genres)}
+      defaultValue={["all"]}
       disableCloseOnSelect
       getOptionLabel={option => option}
       onChange={(event: any, newValue: string[]) => {

--- a/src/components/GenreSelector.tsx
+++ b/src/components/GenreSelector.tsx
@@ -17,8 +17,8 @@ export default function (props: {
     <Autocomplete
       multiple
       fullWidth={true}
-      options={["all"].concat(props.genres)}
-      defaultValue={["all"]}
+      options={["ALL"].concat(props.genres)}
+      defaultValue={["ALL"]}
       disableCloseOnSelect
       getOptionLabel={option => option}
       onChange={(event: any, newValue: string[]) => {

--- a/src/components/MasterPlaylist.tsx
+++ b/src/components/MasterPlaylist.tsx
@@ -62,9 +62,6 @@ export default function MasterPlaylist(
     let map = new Map<string, number>();
     let filter = (t: TrackObj) => !props.usedTracks.some((m: TrackObj) => m.id === t.id);
 
-    if (props.usedTracks.length === props.playlist.tracks.length) {
-      filter = (t: TrackObj) => true;
-    }
     props.playlist.tracks
       .filter(filter)
       .map((t: TrackObj) => t.genres)

--- a/src/components/Subplaylist.tsx
+++ b/src/components/Subplaylist.tsx
@@ -73,7 +73,7 @@ export default function Subplaylist (props: {
   const [trackFilter, setTrackFilter] = useState<TrackFilter>(() => () => true)
 
   const TrackCorrectGenre = (track: TrackObj): boolean => {
-    if (selectedGenres.length === 0) return true
+    if (selectedGenres.includes("all")) return true
     return selectedGenres.some((g: string) => track.genres.includes(g));
   }
 

--- a/src/components/Subplaylist.tsx
+++ b/src/components/Subplaylist.tsx
@@ -73,7 +73,7 @@ export default function Subplaylist (props: {
   const [trackFilter, setTrackFilter] = useState<TrackFilter>(() => () => true)
 
   const TrackCorrectGenre = (track: TrackObj): boolean => {
-    if (selectedGenres.includes("all")) return true
+    if (selectedGenres.includes("ALL")) return true
     return selectedGenres.some((g: string) => track.genres.includes(g));
   }
 

--- a/src/helpers/parsers.tsx
+++ b/src/helpers/parsers.tsx
@@ -107,10 +107,8 @@ export function parseGenres(
   let genres = lm.toptags?.tag
     .filter((t: any) => t.count > 50 && t.name.length < 20)
     .map((t: any) => t.name.toLowerCase())
-    .filter((s: string) => {
-      return s.split(" ").some((g: string) => GENRE_WHITELIST.includes(g))
-        || s.split("-").some((g: string) => GENRE_WHITELIST.includes(g))
-    }) ?? [];
+    .filter((s: string) => s.replace('-', '').split(" ").some((g: string) => GENRE_WHITELIST.includes(g)))
+    ?? [];
   genres.splice(3, 99); // Only keep the first three. The quality goes down quick on some songs
   genres = genres.filter((g: string) => !artistNames.includes(g));
 


### PR DESCRIPTION
<!-- This is a template - do add to or remove from as needed -->
<!-- Please provide a general summary of your changes in the Title above 🚀 -->
## Context

[Corresponding Pivotal Tracker story](https://www.youtube.com/watch?v=dQw4w9WgXcQ)

There is currently no easy way to use only audio features.

## Description 💬
Added an fake "all" genre which includes every song
This "all" genre is selected by default

Also removed dashes from the genres so "hip hop" and "hip-hop" are considered the same

## Checklist ✅:
<!-- Go over all the following points, and check all the boxes. -->
- [ ] I assigned the story to myself on Pivotal Tracker before I started working on this
- [ ] Added a link to the user story context
- [x] Added a description of my changes
- [x] Assigned at least two reviewers
<!-- Once you've checked all of these you can probably delete this checklist for brevity -->
