### PR TITLE
Skip track if it does not have a Spotify Track ID

### DIFF
--- a/src/helpers/parsers.tsx
+++ b/src/helpers/parsers.tsx
@@ -219,13 +219,12 @@ export async function parsePlaylistJSON(
 
         const Q = Queue({ autostart: true, concurrency: 1, timeout: 10 * 1000 })
 
-        // TODO: What if it's a local track?
-
         for await (let trackJSONBare of getPaginationRawGen(
           api.getPlaylistTracks,
           { fields: 'items.track.id,total' },
           this.id
         )) {
+          if (!trackJSONBare.track.id) continue;
           let track = TrackAccumulator.request(
             trackJSONBare['track']['id']
           ).then(async (data: SpotifyApi.TrackObjectFull) =>


### PR DESCRIPTION
Some tracks (i.e. local tracks) do not have a Track ID, which causes the Spotify API to spit out a 400, crashing the program.

This PR proposes to skip those tracks