### PR TITLE
Add refresh drilldown bit to toggle TrackList resizing on feature change

### DIFF
--- a/src/components/GenreSelector.tsx
+++ b/src/components/GenreSelector.tsx
@@ -13,6 +13,7 @@ export default function (props: {
   genres: string[]
   onSelect: (values: string[]) => any
 }) {
+  const displayLimit = 6;
   return (
     <Autocomplete
       multiple
@@ -24,6 +25,8 @@ export default function (props: {
       onChange={(event: any, newValue: string[]) => {
         props.onSelect(newValue)
       }}
+      limitTags={displayLimit}
+      getLimitTagsText={(n) => `and ${n} more genres...`}
       renderOption={(option, { selected }) => (
         <React.Fragment>
           <Checkbox

--- a/src/components/Subplaylist.tsx
+++ b/src/components/Subplaylist.tsx
@@ -78,6 +78,9 @@ export default function Subplaylist(props: {
 }) {
   const classes = useStyles()
 
+  let [eventDrilldown, _setEventDrilldown] = useState(false)
+  const tick = () => _setEventDrilldown(v => !v)
+
   // SAVING ANIMATION STUFF
   const [saveDisabled, setsaveDisabled] = useState(true);
   const [loading, setLoading] = useState(false);
@@ -210,6 +213,7 @@ export default function Subplaylist(props: {
     let view = tracks.filter(trackFilter)
     updateFilteredView(view)
     props.onFilterUpdate && props.onFilterUpdate(view)
+    tick();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tracks, trackFilter, props.onFilterUpdate])
 
@@ -327,6 +331,7 @@ export default function Subplaylist(props: {
           showTrackCount={true}
           toggleChecked={props.toggleChecked}
           checked={props.checked}
+          _refresh={eventDrilldown}
         />
       </List>
     </div>

--- a/src/components/Subplaylist.tsx
+++ b/src/components/Subplaylist.tsx
@@ -46,8 +46,7 @@ const useStyles = makeStyles(theme => ({
     }
   },
   paper: {
-    width: 200,
-    overflow: 'auto'
+    minWidth: 300
   },
   button: {
     margin: theme.spacing(0.5, 0),
@@ -238,7 +237,7 @@ export default function Subplaylist(props: {
           }}
         />
       </Dialog>
-      <List dense component={Paper}>
+      <List dense component={Paper} className={classes.paper}>
         <ListItem style={{ justifyContent: "space-between" }}>
           <Typography>
             {props.playlist.name}

--- a/src/components/TrackList.tsx
+++ b/src/components/TrackList.tsx
@@ -8,7 +8,7 @@ import { ListItem } from "@material-ui/core"
 import { VariableSizeList as VirtualList } from 'react-window'
 import Button from '@material-ui/core/Button/Button'
 
-export default function (props: { id: string; tracks: TrackObj[], isDropDisabled?: boolean, isDragDisabled?: boolean, isDeletable: boolean, isDragClone?: boolean, component: React.ElementType, showActions?: boolean, showTrackCount?: boolean, checked: CheckedList[],  toggleChecked?: (id: string, track: TrackObj) => any}) {
+export default function (props: { id: string; tracks: TrackObj[], isDropDisabled?: boolean, isDragDisabled?: boolean, isDeletable: boolean, isDragClone?: boolean, component: React.ElementType, showActions?: boolean, showTrackCount?: boolean, checked: CheckedList[], _refresh?:boolean, toggleChecked?: (id: string, track: TrackObj) => any}) {
   const [height, setHeight] = useState(0);
 
   const [ref, setRef] = useState<HTMLElement>();
@@ -34,7 +34,7 @@ export default function (props: { id: string; tracks: TrackObj[], isDropDisabled
     return () => {
       window.removeEventListener('resize', checkHeight)
     }
-  }, [ref])
+  }, [ref, props._refresh])
 
   const EntryInvariant = React.memo(({ data, index, style }: any) => (
     data[index] && <TrackEntry


### PR DESCRIPTION
Fixes the TrackList height when features are added/removed.

Abit hackish, gets the job done though; but a similar issue exists with the genre - if it spills over one line